### PR TITLE
Update README to Remove mention of IIS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ To run the project, you'll need to have some basic items set up or installed.
 
 * **Internet.** You'll need an internet connection so that you can restore nuget packages.
 * **Visual Studio**. You'll need Visual Studio to run the examples
-* **IIS**. Because the acceptance tests cannot run at the same time the app is running in IIS express, we have to deploy to IIS itself. Therefore, you'll need to have IIS Installed.
 * **SQL Server**. The acceptance tests and web application use a database, which this example assumes is a SQL Server database.
 * **Selenium Chrome Driver**. We'll need this to run instances of chrome on our machine.
  
@@ -18,13 +17,7 @@ To run the project, you'll need to have some basic items set up or installed.
 
 ### Adding the Selenium Chrome Driver to the PATH variable.
 
-### Creating the IIS Vrtual Directory
-TODO.
-
 ### Running the Migration to Deploy the Database
-TODO.
-
-### Adding Permissions for the IIS Account to the Database 
 TODO.
 
 ### Adding the Initial Payment row to the Database


### PR DESCRIPTION
As of #18 we're back on IIS express, no need to keep the extra IIS doc outline around.