### PR TITLE
Remove build status icon from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![Build Status](https://ci.appveyor.com/api/projects/status/5d629m3s2rm70wxx?svg=true)
-
 # Welcome to the Excella Vending Machine demo!
 This demo shows a working example of a small project with unit tests at each level.
 


### PR DESCRIPTION
The repository is private now and none of the public build tools / CI tools will work with it for free.