### PR TITLE
Pass TransactionScope into ADOPaymentDAO

### DIFF
--- a/Excella.Vending.DAL/ADOPaymentDAO.cs
+++ b/Excella.Vending.DAL/ADOPaymentDAO.cs
@@ -1,44 +1,56 @@
 ﻿using System;
+using System.Configuration;
 using System.Data.SqlClient;
+using System.Transactions;
 
 namespace Excella.Vending.DAL
 {
     public class ADOPaymentDAO : IPaymentDAO
     {
+        private TransactionScope _transactionScope;
+        public ADOPaymentDAO()
+        {
+            _transactionScope = new TransactionScope();
+        }
+
+        public ADOPaymentDAO(TransactionScope transactionScope)
+        {
+            _transactionScope = transactionScope;
+        }
         public int Retrieve()
         {
-            var connection = GetConnection();
-            int payment = 0;
-
-            using (connection)
+            using (var connection = GetConnection())
             {
-                SqlCommand command = new SqlCommand("SELECT Value FROM Payment WHERE ID = 1;", connection);
-                connection.Open();
+                int payment = 0;
 
-                SqlDataReader reader = command.ExecuteReader();
-
-                if (reader.HasRows)
+                using (connection)
                 {
-                    while (reader.Read())
+                    SqlCommand command = new SqlCommand("SELECT Value FROM Payment WHERE ID = 1;", connection);
+                    connection.Open();
+
+                    SqlDataReader reader = command.ExecuteReader();
+
+                    if (reader.HasRows)
                     {
-                        payment = reader.GetInt32(0);
+                        while (reader.Read())
+                        {
+                            payment = reader.GetInt32(0);
+                        }
                     }
-                }
-                else
-                {
-                    Console.WriteLine("No rows found.");
-                }
-                reader.Close();
-            }
+                    else
+                    {
+                        Console.WriteLine("No rows found.");
+                    }
+                    reader.Close();
 
-            return payment;
+                }
+                return payment;
+            }
         }
 
         public void Save(int payment)
         {
-            var connection = GetConnection();
-
-            using (connection)
+            using (var connection = GetConnection())
             {
                 SqlCommand command = new SqlCommand(string.Format("UPDATE Payment SET Value = Value + {0} WHERE ID = 1;", payment), connection);
                 connection.Open();

--- a/Excella.Vending.DAL/ADOPaymentDAO.cs
+++ b/Excella.Vending.DAL/ADOPaymentDAO.cs
@@ -66,9 +66,9 @@ namespace Excella.Vending.DAL
 
         private SqlConnection GetConnection()
         {
-            var connectionString = "Server=.;Database=VendingMachine;Trusted_Connection=True;";
+            string connectionString = ConfigurationManager.ConnectionStrings["VendingMachineContext"]?.ConnectionString;
 
-            return new SqlConnection(connectionString);
+            return new SqlConnection(connectionString ?? "Server=.;Database=VendingMachine;Trusted_Connection=True;");
         }
     }
 }

--- a/Excella.Vending.DAL/Excella.Vending.DAL.csproj
+++ b/Excella.Vending.DAL/Excella.Vending.DAL.csproj
@@ -40,6 +40,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />

--- a/Tests.Integration.Excella.Vending.Web.UI/HomeControllerTests.cs
+++ b/Tests.Integration.Excella.Vending.Web.UI/HomeControllerTests.cs
@@ -24,7 +24,7 @@ namespace Tests.Integration.Excella.Vending.Web.UI
         {
             _transactionScope = new TransactionScope(TransactionScopeOption.RequiresNew);
 
-            var paymentDAO = new ADOPaymentDAO();
+            var paymentDAO = new ADOPaymentDAO(_transactionScope);
             var paymentProcessor = new CoinPaymentProcessor(paymentDAO);
             var vendingMachine = new VendingMachine(paymentProcessor);
             _controller = new HomeController(vendingMachine);


### PR DESCRIPTION
This should allow setup and teardown using TransactionScope and ensure that the integration tests pass.

Resolves #34.

Resolves #36.
