### PR TITLE
In Progress: Retrict Projects to C#5

### DIFF
--- a/Excella.Vending.DAL/ADOPaymentDAO.cs
+++ b/Excella.Vending.DAL/ADOPaymentDAO.cs
@@ -37,7 +37,8 @@ namespace Excella.Vending.DAL
         {
             using (var connection = GetConnection())
             {
-                SqlCommand command = new SqlCommand($"UPDATE Payment SET Value = Value + {payment} WHERE ID = 1;", connection);
+                var sqlCommandString = string.Format("UPDATE Payment SET Value = Value + {0} WHERE ID = 1;", payment);
+                SqlCommand command = new SqlCommand(sqlCommandString, connection);
                 connection.Open();
 
                 var rowsChanged = command.ExecuteNonQuery();

--- a/Excella.Vending.DAL/ADOPaymentDAO.cs
+++ b/Excella.Vending.DAL/ADOPaymentDAO.cs
@@ -87,9 +87,9 @@ namespace Excella.Vending.DAL
 
         private SqlConnection GetConnection()
         {
-            string connectionString = ConfigurationManager.ConnectionStrings["VendingMachineContext"]?.ConnectionString;
+            string connectionString = ConfigurationManager.ConnectionStrings["VendingMachineContext"].ConnectionString;
 
-            return new SqlConnection(connectionString ?? "Server=.;Database=VendingMachine;Trusted_Connection=True;");
+            return new SqlConnection(connectionString);
         }
     }
 }

--- a/Excella.Vending.DAL/ADOPaymentDAO.cs
+++ b/Excella.Vending.DAL/ADOPaymentDAO.cs
@@ -55,7 +55,8 @@ namespace Excella.Vending.DAL
             const int PURCHASE_PRICE = 50;
             using (var connection = GetConnection())
             {
-                SqlCommand command = new SqlCommand($"UPDATE Payment SET Value = Value - {PURCHASE_PRICE} WHERE ID = 1;", connection);
+                var commandText = string.Format("UPDATE Payment SET Value = Value - {0} WHERE ID = 1;", PURCHASE_PRICE);
+                SqlCommand command = new SqlCommand(commandText, connection);
                 connection.Open();
 
                 var rowsChanged = command.ExecuteNonQuery();

--- a/Excella.Vending.DAL/Excella.Vending.DAL.csproj
+++ b/Excella.Vending.DAL/Excella.Vending.DAL.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Excella.Vending.Domain/CoinPaymentProcessor.cs
+++ b/Excella.Vending.Domain/CoinPaymentProcessor.cs
@@ -4,7 +4,10 @@ namespace Excella.Vending.Domain
 {
     public class CoinPaymentProcessor : IPaymentProcessor
     {
-        public int Payment => _paymentDAO.Retrieve();
+        public int Payment
+        {
+            get { return _paymentDAO.Retrieve(); }
+        }
 
         private IPaymentDAO _paymentDAO;
 

--- a/Excella.Vending.Domain/Excella.Vending.Domain.csproj
+++ b/Excella.Vending.Domain/Excella.Vending.Domain.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Excella.Vending.Machine/Excella.Vending.Machine.csproj
+++ b/Excella.Vending.Machine/Excella.Vending.Machine.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Excella.Vending.Web.UI/Excella.Vending.Web.UI.csproj
+++ b/Excella.Vending.Web.UI/Excella.Vending.Web.UI.csproj
@@ -34,6 +34,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Excella.Vending.sln.dotSettings
+++ b/Excella.Vending.sln.dotSettings
@@ -1,0 +1,3 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+    <s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String>
+</wpf:ResourceDictionary>

--- a/Tests.Acceptance.Excella.Vending.Machine/Tests.Acceptance.Excella.Vending.Machine.csproj
+++ b/Tests.Acceptance.Excella.Vending.Machine/Tests.Acceptance.Excella.Vending.Machine.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/IISExpressTestManager.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/IISExpressTestManager.cs
@@ -33,7 +33,7 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
             var applicationPath = GetApplicationPath(APPLICATION_NAME);
             var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
             var startInfoFileName = programFiles + @"\IIS Express\iisexpress.exe";
-            var startInfoArguments = $"/config:\"{applicationPath}\\..\\..\\..\\.vs\\config\\applicationhost.config\"";
+            var startInfoArguments = string.Format("/config:\"{0}\\..\\..\\..\\.vs\\config\\applicationhost.config\"", applicationPath);
 
             var iisProcess = new Process
             {

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.csproj
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests.Integration.Excella.Vending.Machine/Tests.Integration.Excella.Vending.Machine.csproj
+++ b/Tests.Integration.Excella.Vending.Machine/Tests.Integration.Excella.Vending.Machine.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests.Integration.Excella.Vending.Web.UI/Tests.Integration.Excella.Vending.Web.UI.csproj
+++ b/Tests.Integration.Excella.Vending.Web.UI/Tests.Integration.Excella.Vending.Web.UI.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests.Unit.Excella.Vending.Domain/Tests.Unit.Excella.Vending.Domain.csproj
+++ b/Tests.Unit.Excella.Vending.Domain/Tests.Unit.Excella.Vending.Domain.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Tests.Unit.Excella.Vending.Machine/Tests.Unit.Excella.Vending.Machine.csproj
+++ b/Tests.Unit.Excella.Vending.Machine/Tests.Unit.Excella.Vending.Machine.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Resolves #45. 

## Work Remaining
* [x] Restrict Acceptance Tests Projects
* [x] Restrict integration test projects
* [x] Restrict unit test projects
* [x] Restrict code projects
* [x] Update ReSharper settings for project (so resharper doesn't try to "help" us with C#6 ideas).

## How I'm doing this
To update the project language version, for each project, I am:

* Going to the properties for that project (Right-click --> Properties or `ALT + Enter`)
* Go to the Build Tab
* Click the `Advanced` button
* Change language version from `latest` to `C# 5`.