### PR TITLE
Update arrange/act sections

### DIFF
--- a/Tests.Integration.Excella.Vending.Machine/VendingMachineTests.cs
+++ b/Tests.Integration.Excella.Vending.Machine/VendingMachineTests.cs
@@ -75,8 +75,8 @@ namespace Tests.Integration.Excella.Vending.Machine
             _vendingMachine.InsertCoin();
             _vendingMachine.InsertCoin();
             _vendingMachine.InsertCoin();
-
             _vendingMachine.BuyProduct();
+
             var change = _vendingMachine.ReleaseChange();
 
             Assert.AreEqual(25, change);

--- a/Tests.Integration.Excella.Vending.Web.UI/VendingMachineControllerTests.cs
+++ b/Tests.Integration.Excella.Vending.Web.UI/VendingMachineControllerTests.cs
@@ -79,10 +79,9 @@ namespace Tests.Integration.Excella.Vending.Web.UI
             _controller.InsertCoin();
 
             _controller.ReleaseChange();
+
             _controller.Index();
-
             var vm = _controller.ViewData.Model as VendingMachineViewModel;
-
             Assert.AreEqual(0, vm.Balance);
         }
     }

--- a/Tests.Integration.Excella.Vending.Web.UI/VendingMachineControllerTests.cs
+++ b/Tests.Integration.Excella.Vending.Web.UI/VendingMachineControllerTests.cs
@@ -48,7 +48,6 @@ namespace Tests.Integration.Excella.Vending.Web.UI
             _controller.Index();
 
             var vm = _controller.ViewData.Model as VendingMachineViewModel;
-
             Assert.That(vm.Balance, Is.EqualTo(0));
         }
 

--- a/Tests.Unit.Excella.Vending.Domain/CoinPaymentProcessorTests.cs
+++ b/Tests.Unit.Excella.Vending.Domain/CoinPaymentProcessorTests.cs
@@ -22,6 +22,7 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void Payment_WhenNoMoney_ExpectBalanceIsZero()
         {
             _paymentDAO.Setup(d => d.Retrieve()).Returns(0);
+
             var balance = _paymentProcessor.Payment;
 
             Assert.AreEqual(0, balance);

--- a/Tests.Unit.Excella.Vending.Domain/CoinPaymentProcessorTests.cs
+++ b/Tests.Unit.Excella.Vending.Domain/CoinPaymentProcessorTests.cs
@@ -32,6 +32,7 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void Payment_WhenMoney_ExpectBalanceIsNotZero()
         {
             _paymentDAO.Setup(d => d.Retrieve()).Returns(25);
+
             var balance = _paymentProcessor.Payment;
 
             Assert.AreEqual(25, balance);
@@ -41,6 +42,7 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void IsPaymentMade_WhenNoMoney_ExpectFalse()
         {
             _paymentDAO.Setup(d => d.Retrieve()).Returns(0);
+
             var actual = _paymentProcessor.IsPaymentMade();
 
             Assert.AreEqual(false, actual);
@@ -50,6 +52,7 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void IsPaymentMade_WhenLessThan50Cents_ExpectFalse()
         {
             _paymentDAO.Setup(d => d.Retrieve()).Returns(25);
+
             var actual = _paymentProcessor.IsPaymentMade();
 
             Assert.AreEqual(false, actual);
@@ -59,6 +62,7 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void IsPaymentMade_When50Cents_ExpectTrue()
         {
             _paymentDAO.Setup(d => d.Retrieve()).Returns(50);
+
             var actual = _paymentProcessor.IsPaymentMade();
 
             Assert.AreEqual(true, actual);
@@ -68,6 +72,7 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void IsPaymentMade_WhenGreaterThan50Cents_ExpectTrue()
         {
             _paymentDAO.Setup(d => d.Retrieve()).Returns(75);
+
             var actual = _paymentProcessor.IsPaymentMade();
 
             Assert.AreEqual(true, actual);
@@ -77,7 +82,9 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void ProcessPayment_WhenPaymentMade_ExpectSavedToDB()
         {
             _paymentDAO.Setup(d => d.SavePayment(It.IsAny<int>())).Verifiable();
+
             _paymentProcessor.ProcessPayment(25);
+
             _paymentDAO.Verify(d => d.SavePayment(25), Times.Once);
         }
 
@@ -85,6 +92,7 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void ProcessPurchase_WhenPurchaseMade_ExpectSavedToDB()
         {
             _paymentProcessor.ProcessPurchase();
+
             _paymentDAO.Verify(d => d.SavePurchase(), Times.Once);
         }
 
@@ -92,6 +100,7 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void ClearPayment_WhenPaymentHasBeenMade_TellsDaoToClearPayment()
         {
             _paymentDAO.Setup(x => x.Retrieve()).Returns(25);
+
             _paymentProcessor.ClearPayments();
             
             _paymentDAO.Verify(x=>x.ClearPayments(), Times.Once);
@@ -101,6 +110,7 @@ namespace Tests.Unit.Excella.Vending.Domain
         public void ClearPayment_WhenPaymentHasNotBeenMade_DoesNotTellDaoToClearPayment()
         {
             _paymentDAO.Setup(x => x.Retrieve()).Returns(0);
+
             _paymentProcessor.ClearPayments();
 
             _paymentDAO.Verify(x => x.ClearPayments(), Times.Never);

--- a/Tests.Unit.Excella.Vending.Machine/VendingMachineTests.cs
+++ b/Tests.Unit.Excella.Vending.Machine/VendingMachineTests.cs
@@ -23,6 +23,7 @@ namespace Tests.Unit.Excella.Vending.Machine
         public void ReleaseChange_WhenNoMoneyInserted_ExpectZero()
         {
             _paymentProcessor.Setup(p => p.Payment).Returns(0);
+
             var change = _vendingMachine.ReleaseChange();
 
             Assert.AreEqual(0, change);
@@ -89,6 +90,7 @@ namespace Tests.Unit.Excella.Vending.Machine
         public void GetMessage_WhenMoneyInserted_ExpectEnjoyPrompt()
         {
             _paymentProcessor.Setup(p => p.IsPaymentMade()).Returns(true);
+
             _vendingMachine.BuyProduct();
 
             var message = _vendingMachine.Message;
@@ -100,6 +102,7 @@ namespace Tests.Unit.Excella.Vending.Machine
         public void ReleaseChange_WhenCoinInserted_CallsPaymentProcessorToResetPayment()
         {
             _paymentProcessor.Setup(x => x.Payment).Returns(25);
+
             _vendingMachine.ReleaseChange();
 
             _paymentProcessor.Verify(x=>x.ClearPayments(), Times.Once);


### PR DESCRIPTION
Resolves #77.

Per conversation with Fadi, this ensures all arrange steps are at the top and ensures the actions are separated by a line. 