### PR TITLE
Use Selenium waits to replace try/catch blocks

### DIFF
--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -145,14 +145,9 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
 
         private int GetBalance()
         {
-            try
-            {
-                return int.Parse(_browser.FindElement(By.Id("balanceAmount")).Text);
-            }
-            catch (StaleElementReferenceException)
-            {
-                return GetBalance();
-            }
+            var wait = new WebDriverWait(_browser, TimeSpan.FromSeconds(10));
+            var element = wait.Until(drv => drv.FindElement(By.Id("balanceAmount"))).Text;
+            return int.Parse(element);
         }
     }
 }

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Support.UI;
 using TechTalk.SpecFlow;
 
 namespace Tests.Acceptance.Web.Excella.Vending.Machine
@@ -125,22 +126,15 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
 
         private int GetReleasedChange()
         {
-            try
-            {
-                var element = _browser.FindElement(By.Id("releasedChangeAmount")).Text;
+            var wait = new WebDriverWait(_browser, TimeSpan.FromSeconds(10));
 
-                int changeAmt;
-                if (int.TryParse(element, out changeAmt))
-                {
-                    return changeAmt;
-                }
-
-                return 0;
-            }
-            catch (StaleElementReferenceException)
+            var element = wait.Until(drv => drv.FindElement(By.Id("releasedChangeAmount"))).Text;
+            int changeAmt;
+            if (int.TryParse(element, out changeAmt))
             {
-                return GetReleasedChange();
+                return changeAmt;
             }
+            return 0;
         }
 
         private void ClickInsertCoinButton()

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.csproj
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/Tests.Acceptance.Web.Excella.Vending.Machine.csproj
@@ -48,9 +48,11 @@
       <HintPath>..\packages\SpecFlow.2.1.0\lib\net45\TechTalk.SpecFlow.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.8.0\lib\net45\WebDriver.dll</HintPath>
+    </Reference>
+    <Reference Include="WebDriver.Support, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.8.0\lib\net45\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/packages.config
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.5.0" targetFramework="net452" />
-  <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net452" />
+  <package id="Selenium.Support" version="3.8.0" targetFramework="net452" />
+  <package id="Selenium.WebDriver" version="3.8.0" targetFramework="net452" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net452" />
   <package id="SpecFlow.NUnit" version="2.1.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Resolves #86.
Resolves #87.

Updates selenium and adds `Selenium.Support` which allows us to use waits which is much cleaner than try/catches with infinite retries. 