### PR TITLE
Return null product instead of throwing exception

### DIFF
--- a/Excella.Vending.Machine/VendingMachine.cs
+++ b/Excella.Vending.Machine/VendingMachine.cs
@@ -42,7 +42,7 @@ namespace Excella.Vending.Machine
             }
 
             Message = "Please insert money";
-            throw new InvalidOperationException();
+            return null;
         }
     }
 }

--- a/Tests.Unit.Excella.Vending.Machine/VendingMachineTests.cs
+++ b/Tests.Unit.Excella.Vending.Machine/VendingMachineTests.cs
@@ -82,7 +82,7 @@ namespace Tests.Unit.Excella.Vending.Machine
         {
             _paymentProcessor.Setup(p => p.IsPaymentMade()).Returns(false);
 
-            Assert.That(()=> _vendingMachine.BuyProduct(), Throws.InvalidOperationException);
+            _vendingMachine.BuyProduct();
 
             Assert.That(_vendingMachine.Message, Is.EqualTo("Please insert money"));
         }

--- a/Tests.Unit.Excella.Vending.Machine/VendingMachineTests.cs
+++ b/Tests.Unit.Excella.Vending.Machine/VendingMachineTests.cs
@@ -62,8 +62,8 @@ namespace Tests.Unit.Excella.Vending.Machine
         {
             _paymentProcessor.Setup(p => p.IsPaymentMade()).Returns(false);
 
+            _vendingMachine.BuyProduct();
 
-            Assert.That(() => _vendingMachine.BuyProduct(), Throws.InvalidOperationException);
             _paymentProcessor.Verify(x => x.ProcessPurchase(), Times.Never);
         }
 

--- a/Tests.Unit.Excella.Vending.Machine/VendingMachineTests.cs
+++ b/Tests.Unit.Excella.Vending.Machine/VendingMachineTests.cs
@@ -40,11 +40,11 @@ namespace Tests.Unit.Excella.Vending.Machine
         }
 
         [Test]
-        public void BuyProduct_WhenNoMoneyInserted_ExpectException()
+        public void BuyProduct_WhenNoMoneyInserted_ExpectNull()
         {
             _paymentProcessor.Setup(p => p.IsPaymentMade()).Returns(false);
 
-            Assert.That(()=> _vendingMachine.BuyProduct(), Throws.InvalidOperationException);
+            Assert.That(()=> _vendingMachine.BuyProduct(), Is.Null);
         }
 
         [Test]
@@ -61,6 +61,7 @@ namespace Tests.Unit.Excella.Vending.Machine
         public void BuyProduct_WhenPaymentNotMade_DoesNotCallPaymentProcessorToProcessPurchase()
         {
             _paymentProcessor.Setup(p => p.IsPaymentMade()).Returns(false);
+
 
             Assert.That(() => _vendingMachine.BuyProduct(), Throws.InvalidOperationException);
             _paymentProcessor.Verify(x => x.ProcessPurchase(), Times.Never);


### PR DESCRIPTION
Since we teach largely with a null `Product` example now and now exceptions being thrown.