### PR TITLE
Remove calls to ReleaseChange

### DIFF
--- a/Tests.Integration.Excella.Vending.Machine/VendingMachineTestsADO.cs
+++ b/Tests.Integration.Excella.Vending.Machine/VendingMachineTestsADO.cs
@@ -25,8 +25,6 @@ namespace Tests.Integration.Excella.Vending.Machine
             _transactionScope = new TransactionScope();
             var paymentProcessor = new CoinPaymentProcessor(_paymentDao);
             _vendingMachine = new VendingMachine(paymentProcessor);
-
-            _vendingMachine.ReleaseChange();
         }
 
         [TearDown]

--- a/Tests.Integration.Excella.Vending.Machine/VendingMachineTestsEF.cs
+++ b/Tests.Integration.Excella.Vending.Machine/VendingMachineTestsEF.cs
@@ -25,8 +25,6 @@ namespace Tests.Integration.Excella.Vending.Machine
             _paymentDAO = new EFPaymentDAO();
             var paymentProcessor = new CoinPaymentProcessor(_paymentDAO);
             _vendingMachine = new VendingMachine(paymentProcessor);
-
-            _vendingMachine.ReleaseChange();
         }
 
         [TearDown]


### PR DESCRIPTION
Resolves #81. 

All tests still pass.

Calls to clear the payment still exist at the test fixture level, but that's in case we demo the app. A one-time reset at the fixture level seems acceptable.