### PR TITLE
Fix: Direct assertion instead of relative assertion

### DIFF
--- a/Tests.Integration.Excella.Vending.Machine/VendingMachineTestsADO.cs
+++ b/Tests.Integration.Excella.Vending.Machine/VendingMachineTestsADO.cs
@@ -36,13 +36,11 @@ namespace Tests.Integration.Excella.Vending.Machine
         [Test]
         public void InsertCoin_WhenOneCoinInserted_ExpectIncreaseOf25()
         {
-           var originalBalance = _vendingMachine.Balance;
-
             _vendingMachine.InsertCoin();
 
             var currentBalance = _vendingMachine.Balance;
 
-            Assert.That(currentBalance, Is.EqualTo(originalBalance + 25));
+            Assert.That(currentBalance, Is.EqualTo(25));
         }
 
         [Test]

--- a/Tests.Integration.Excella.Vending.Machine/VendingMachineTestsEF.cs
+++ b/Tests.Integration.Excella.Vending.Machine/VendingMachineTestsEF.cs
@@ -36,13 +36,11 @@ namespace Tests.Integration.Excella.Vending.Machine
         [Test]
         public void InsertCoin_WhenOneCoinInserted_ExpectIncreaseOf25()
         {
-           var originalBalance = _vendingMachine.Balance;
-
             _vendingMachine.InsertCoin();
 
             var currentBalance = _vendingMachine.Balance;
 
-            Assert.That(currentBalance, Is.EqualTo(originalBalance + 25));
+            Assert.That(currentBalance, Is.EqualTo(25));
         }
 
         [Test]


### PR DESCRIPTION
Resolves #76.

## Problem

We were asserting `currentBalance + 25`, rather than just `25`. This was leftover cruft because our Fixture wasn't cleaning itself up properly.

## Solution
Just assert `25`. It works just fine.