### PR TITLE
make browser actions explicit

### DIFF
--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -66,7 +66,9 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         [Then(@"The balance should be (.*) cents")]
         public void TheBalanceShouldBe(int cents)
         {
-            var balance = GetBalance();
+            var wait = new WebDriverWait(Browser, TimeSpan.FromSeconds(10));
+            var element = wait.Until(drv => drv.FindElement(By.Id("balanceAmount"))).Text;
+            var balance = int.Parse(element);
 
             Assert.That(balance, Is.EqualTo(cents));
         }
@@ -124,13 +126,6 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         public void ThenIShouldNotReceiveAProduct()
         {
             //Assert.IsNull(product);
-        }
-
-        private int GetBalance()
-        {
-            var wait = new WebDriverWait(Browser, TimeSpan.FromSeconds(10));
-            var element = wait.Until(drv => drv.FindElement(By.Id("balanceAmount"))).Text;
-            return int.Parse(element);
         }
     }
 }

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -100,7 +100,9 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         [Then(@"I should receive (.*) cents in change")]
         public void ThenIShouldReceiveXCentsInChange(int cents)
         {
-            var releasedChange = GetReleasedChange();
+            var wait = new WebDriverWait(Browser, TimeSpan.FromSeconds(10));
+            var elementText = wait.Until(drv => drv.FindElement(By.Id("releasedChangeAmount"))).Text;
+            var releasedChange = int.Parse(elementText);
 
             Assert.That(releasedChange, Is.EqualTo(cents));
         }
@@ -122,19 +124,6 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         public void ThenIShouldNotReceiveAProduct()
         {
             //Assert.IsNull(product);
-        }
-
-        private int GetReleasedChange()
-        {
-            var wait = new WebDriverWait(Browser, TimeSpan.FromSeconds(10));
-
-            var element = wait.Until(drv => drv.FindElement(By.Id("releasedChangeAmount"))).Text;
-            int changeAmt;
-            if (int.TryParse(element, out changeAmt))
-            {
-                return changeAmt;
-            }
-            return 0;
         }
 
         private int GetBalance()

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -52,7 +52,8 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         [AfterScenario]
         public void Teardown()
         {
-            ClickReleaseChangeButton();
+            var button = Browser.FindElement(By.Id("releaseChange"));
+            button.Click();
         }
 
         [When(@"I insert a Quarter")]
@@ -90,7 +91,8 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         [When(@"I release the change")]
         public void WhenIReleaseTheChange()
         {
-            ClickReleaseChangeButton();
+            var button = Browser.FindElement(By.Id("releaseChange"));
+            button.Click();
         }
 
         [Then(@"I should receive (.*) cents in change")]
@@ -123,13 +125,6 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         private void GoToHomePage()
         {
             Browser.Navigate().GoToUrl(HOME_PAGE_URL);
-        }
-
-        private void ClickReleaseChangeButton()
-        {
-            var button = Browser.FindElement(By.Id("releaseChange"));
-
-            button.Click();
         }
 
         private int GetReleasedChange()

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -59,7 +59,8 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         [When(@"I insert a Quarter")]
         public void WhenIInsertAQuarter()
         {
-            ClickInsertCoinButton();
+            var button = Browser.FindElement(By.Id("insertCoin"));
+            button.Click();
         }
 
         [Then(@"The balance should be (.*) cents")]
@@ -73,7 +74,8 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         [Given(@"I have inserted a quarter")]
         public void GivenIHaveInsertedAQuarter()
         {
-            ClickInsertCoinButton();
+            var button = Browser.FindElement(By.Id("insertCoin"));
+            button.Click();
         }
 
         [When("I do not purchase a product")]
@@ -133,12 +135,6 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
                 return changeAmt;
             }
             return 0;
-        }
-
-        private void ClickInsertCoinButton()
-        {
-            var button = Browser.FindElement(By.Id("insertCoin"));
-            button.Click();
         }
 
         private int GetBalance()

--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -46,7 +46,7 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
                 throw new Exception("IIS Express must be running for this test to work");
             }
 
-            GoToHomePage();
+            Browser.Navigate().GoToUrl(HOME_PAGE_URL);
         }
 
         [AfterScenario]
@@ -120,11 +120,6 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         public void ThenIShouldNotReceiveAProduct()
         {
             //Assert.IsNull(product);
-        }
-
-        private void GoToHomePage()
-        {
-            Browser.Navigate().GoToUrl(HOME_PAGE_URL);
         }
 
         private int GetReleasedChange()


### PR DESCRIPTION
Resolves #88.

## Problem
Per Fadi, during training it can be difficult for trainees to comprehend the browser actions when they're abstracted away. 

## Solution
Though it looks slightly less clean, for the sake of understandability in class, we'll remove these abstractions.