### PR TITLE
Remove exception in test that uses IISExpressTestManager

### DIFF
--- a/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
+++ b/Tests.Acceptance.Web.Excella.Vending.Machine/BuyProductSteps.cs
@@ -41,11 +41,6 @@ namespace Tests.Acceptance.Web.Excella.Vending.Machine
         [BeforeScenario]
         public void Setup()
         {
-            if (!IISExpressTestManager.IsIISExpressRunning())
-            {
-                throw new Exception("IIS Express must be running for this test to work");
-            }
-
             Browser.Navigate().GoToUrl(HOME_PAGE_URL);
         }
 


### PR DESCRIPTION
Resolves #106.

Per Fadi, if IIS Express isn't working right, the tests will just fail and have the stack trace anyway. Makes sense to me.