### PR TITLE
Fix integration tests

### DIFF
--- a/Tests.Integration.Excella.Vending.Web.UI/VendingMachineControllerTestsADO.cs
+++ b/Tests.Integration.Excella.Vending.Web.UI/VendingMachineControllerTestsADO.cs
@@ -62,8 +62,7 @@ namespace Tests.Integration.Excella.Vending.Web.UI
         {
             _controller.InsertCoin();
 
-            var result = _controller.ReleaseChange() as RedirectToRouteResult;
-            var actionName = result.RouteValues["action"];
+            var result = _controller.ReleaseChange() as RedirectToActionResult;
             var releasedChange = result.RouteValues["ReleasedChange"];
 
             Assert.That(releasedChange, Is.EqualTo(25));

--- a/Tests.Integration.Excella.Vending.Web.UI/VendingMachineControllerTestsEF.cs
+++ b/Tests.Integration.Excella.Vending.Web.UI/VendingMachineControllerTestsEF.cs
@@ -63,8 +63,8 @@ namespace Tests.Integration.Excella.Vending.Web.UI
         {
             _controller.InsertCoin();
 
-            var result = _controller.ReleaseChange() as RedirectToRouteResult;
-            var actionName = result.RouteValues["action"];
+            var result = _controller.ReleaseChange() as RedirectToActionResult;
+
             var releasedChange = result.RouteValues["ReleasedChange"];
 
             Assert.That(releasedChange, Is.EqualTo(25));


### PR DESCRIPTION
Resolves #118.

The integration tests for the release change method in the web project were failing, per #118.

This is because they were making an explicit cast to `RedirectToRoute` in order to determine some of the route values. However, in the update to .NET Core, RedirectToRoute was updated to be `RedirectToAction`, and the test code was not appropriately updated. Hence, the failure.

This PR fixes the integration test by fixing the explicit casting within that test, and also removes an unused variable for cleanup.